### PR TITLE
Prepare for ocrd_all release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+	pip install .
+
+install-dev:
+	pip install -e .

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Perform font classification and text recognition (in one step) on historic docum
     > iterating over the element hierarchy down to the text line level.
 
     > Then for each line, retrieve the raw image and feed it to the font
-    > classifier (optionally) and the OCR.
+    > classifier and/or the  OCR.
 
     > Annotate font predictions by name and score as a comma-separated
     > list under ``./TextStyle/@fontFamily``, if any.
@@ -60,24 +60,26 @@ OCR-D processor interface ocrd-froc
 
 To be used with PAGE-XML documents in an OCR-D annotation workflow.
 
+```
 Parameters:
 
-    "method" [string - "adaptive"]
-    Possible values: ["SelOCR", "COCR", "adaptive"]
+   "ocr_method" [string - "none"]
     The method to use for text recognition
-    
-    "network" [string]
-    The file name of the neural network to use, including sufficient path information
-
-    "fast_cocr": [boolean - True]
+    Possible values: ["none", "SelOCR", "COCR", "adaptive"]
+   "replace_textstyle" [bool - true]
+    Whether to replace existing textStyle
+   "network" [string]
+    The file name of the neural network to use, including sufficient path
+    information. Defaults to the model bundled with ocrd_froc.
+   "fast_cocr" [boolean - true]
     Whether to use optimization steps on the COCR strategy
-
-    "adaptive_treshold": [integer - 95]
-    Treshold of certitude needed to use SelOCR when using the adaptive strategy
-
-    "font_class_priors": [array]
-    Possible values: ["antiqua", "bastarda", "fraktur", "textura", "schwabacher", "greek", "italic", "hebrew", "gotico-antiqua", "manuscript", "rotunda", "other"]
-    List of font classes which are known to be present on the data when using the 
-    adaptive/SelOCR strategies. When this option is specified, every font classes 
-    not included will be ignored. If 'other' is included in the list, font 
-    classification will not be outputted and a generic model will be used for transcriptions. 
+   "adaptive_treshold" [number - 95]
+    Treshold of certitude needed to use SelOCR when using the adaptive
+    strategy
+   "font_class_priors" [array - []]
+    List of font classes which are known to be present on the data when
+    using the adaptive/SelOCR strategies. When this option is specified,
+    every font classes not included will be ignored. If 'other' is
+    included in the list, font classification will not be outputted and
+    a generic model will be used for transcriptions.
+```

--- a/ocrd_froc/classmap.py
+++ b/ocrd_froc/classmap.py
@@ -1,30 +1,30 @@
 class IndexRemap:
     """ Utility class for remapping class indices.
-    
+
         Attributes
         ----------
         id2id: dictionary
             map from source to target index
     """
-    
+
     def __init__(self, id2id):
-        """ 
+        """
             Parameters
             ----------
-            
+
             id2id: dictionary int to int
                 map from source to target index
         """
         self.id2id = id2id
-    
+
     def __call__(self, n):
         """ Remaps an index, returns -1 if the input index is not known
-        
+
         """
         if not n in self.id2id:
             return -1
         return self.id2id[n]
-    
+
     def __repr__(self):
         format_string = self.__class__.__name__ + '('
         for k in self.id2id:
@@ -34,38 +34,38 @@ class IndexRemap:
 
 class ClassMap:
     """ Class wrapping type group information and a classifier.
-    
+
         Attributes
         ----------
-        
+
         cl2id: dictionary string to int
             Maps a class name to a class number
         id2cl: dictionary int to string
             Maps a class number to a class name
     """
-    
+
     def __init__(self, basemap):
         """ Constructor of the class.
-        
+
             Parameters
             ----------
-            
+
             basemap: map string to int
                 Maps names to IDs with regard to the network outputs;
                 note that several names can point to the same ID, but
                 the inverse is not possible.
         """
-        
+
         self.cl2id = {}
         self.id2cl = {}
         for c in basemap:
             self.cl2id[c] = basemap[c]
             self.id2cl[basemap[c]] = c
-    
+
     def forget_class(self, target):
         del self.id2cl[self.cl2id[target]]
         del self.cl2id[target]
-    
+
     def translate(self, dictionary):
         for name in self.cl2id:
             if not name in dictionary:
@@ -74,19 +74,19 @@ class ClassMap:
             del self.cl2id[name]
             self.cl2id[dictionary[name]] = n
             self.id2cl[n] = dictionary[name]
-       
+
     def get_target_transform(self, dataset_classes):
         """ Creates a transform from a map (class name to id) to the
             set of IDs used by this class map. Unmatched classes are
             mapped to -1.
-            
+
             This method is useful for producing target transforms for
             PyTorch ImageFolder. Proceed as follows:
                 imf = ImageFolder('/path')
                 imf.target_transform = cm.get_target_transform(imf.class_to_idx)
             where cm is a ClassMap instance.
         """
-        
+
         idmap = {}
         for c in dataset_classes:
             if not c in self.cl2id:
@@ -94,6 +94,6 @@ class ClassMap:
             else:
                 idmap[dataset_classes[c]] = self.cl2id[c]
         return IndexRemap(idmap)
-    
+
     def __repr__(self):
         return '%s' % self.cl2id

--- a/ocrd_froc/converter.py
+++ b/ocrd_froc/converter.py
@@ -12,7 +12,7 @@ class Converter(object):
         self.letters = {l:(n+1) for n, l in enumerate(letters)}
         self.n_classes = len(letters)+1
         self.reverse = {self.letters[l]:l for l in self.letters} | {0: ''}
-    
+
     def encode(self, text, pad=True):
         if isinstance(text, str):
             s = split(text)
@@ -29,7 +29,7 @@ class Converter(object):
                 while len(e)<mx:
                     e.append(0)
         return torch.Tensor(encodings).int(), torch.Tensor(lengths).int()
-    
+
     def raw(self, encodings):
         n = len(encodings.shape)
         if n>3:
@@ -46,7 +46,7 @@ class Converter(object):
             return res
         if n==3:
             return self.raw(torch.argmax(encodings, 2))
-    
+
     def decode(self, encodings, scores, base_width=None):
         n = len(encodings.shape)
         if n>2:
@@ -54,7 +54,7 @@ class Converter(object):
         if n==1:
             l = []
             prev = None
-            
+
             score_max = 0
             scores_sum = 0
             for i in range(min(encodings.shape[0], base_width)):

--- a/ocrd_froc/converter.py
+++ b/ocrd_froc/converter.py
@@ -4,6 +4,9 @@ import numpy as np
 
 wtf_pattern = re.compile(r'(.[\u02F3\u1D53\u0300\u2013\u032E\u208D\u203F\u0311\u0323\u035E\u031C\u02FC\u030C\u02F9\u0328\u032D\u02F4\u032F\u0330\u035C\u0302\u0327\u0357\u0308\u0351\u0304\u02F2\u0352\u0355\u032C\u030B\u0339\u0301\u02F1\u0303\u0306\u030A\u0325\u0307\u0354\u02F0\u0060\u030d\u0364\u0303]*)', re.UNICODE | re.IGNORECASE)
 def split(s):
+    """
+    Split string with accented letters
+    """
     return list(wtf_pattern.findall(s))
 
 

--- a/ocrd_froc/froc.py
+++ b/ocrd_froc/froc.py
@@ -1,10 +1,12 @@
-import _io
-import torch
+from io import BufferedReader, BufferedWriter
 import pickle
-from torchvision import transforms
+
+import torch    # type: ignore
+from torchvision import transforms    # type: ignore
 from PIL import Image
 
-import torch.nn.functional as F
+import torch.nn.functional as F    # type: ignore
+
 from ocrd_froc.converter import Converter
 from ocrd_froc.classmap import ClassMap
 
@@ -73,7 +75,7 @@ class Froc:
         if isinstance(inp, str):
             with open(inp, 'rb') as f:
                 return cls.load(f)
-        if not isinstance(inp, _io.BufferedReader):
+        if not isinstance(inp, BufferedReader):
             raise ValueError(f'Froc.load() requires a string or a file, this is neither: {inp}')
         res = pickle.load(inp)
         # If trained with CUDA and loaded on a device without CUDA
@@ -96,7 +98,7 @@ class Froc:
             with open(output, 'wb') as f:
                 self.save(f)
                 return
-        if not isinstance(output, _io.BufferedWriter):
+        if not isinstance(output, BufferedWriter):
             raise ValueError(f'Froc.save() requires a string or a file, this is neither: {output}')
         # Moving the network to the cpu so that it can be reloaded on
         # machines which do not have CUDA available.

--- a/ocrd_froc/network.py
+++ b/ocrd_froc/network.py
@@ -1,8 +1,6 @@
 import os
-import copy
-import numpy as np
-import torch
-import torch.nn.functional as F
+import torch    # type: ignore
+import torch.nn.functional as F    # type: ignore
 import json
 from os.path import join
 

--- a/ocrd_froc/ocrd-tool.json
+++ b/ocrd_froc/ocrd-tool.json
@@ -22,7 +22,7 @@
           "default": "adaptive"
         },
         "network": {
-          "description": "The file name of the neural network to use, including sufficient path information",
+          "description": "The file name of the neural network to use, including sufficient path information. Defaults to the model bundled with ocrd_froc.",
           "type": "string",
           "required": false
         },

--- a/ocrd_froc/ocrd-tool.json
+++ b/ocrd_froc/ocrd-tool.json
@@ -23,7 +23,7 @@
         },
         "replace_textstyle": {
           "description": "Whether to replace existing textStyle",
-          "type": "bool",
+          "type": "boolean",
           "required": false,
           "default": true
         },

--- a/ocrd_froc/ocrd-tool.json
+++ b/ocrd_froc/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
   "version": "0.4.0",
-  "git_url": "https://github.com/MegaloPat/ocrd_froc",
+  "git_url": "https://github.com/OCR-D/ocrd_froc",
   "tools": {
     "ocrd-froc": {
       "executable": "ocrd-froc",
@@ -15,11 +15,17 @@
       "input_file_grp": ["OCR-D-SEG"],
       "output_file_grp": ["OCR-D-OCR"],
       "parameters": {
-        "method": {
+        "ocr_method": {
           "description": "The method to use for text recognition",
           "type": "string",
-          "enum": ["SelOCR", "COCR", "adaptive"],
-          "default": "adaptive"
+          "enum": ["none", "SelOCR", "COCR", "adaptive"],
+          "default": "none"
+        },
+        "replace_textstyle": {
+          "description": "Whether to replace existing textStyle",
+          "type": "bool",
+          "required": false,
+          "default": true
         },
         "network": {
           "description": "The file name of the neural network to use, including sufficient path information. Defaults to the model bundled with ocrd_froc.",
@@ -42,7 +48,20 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["antiqua", "bastarda", "fraktur", "textura", "schwabacher", "greek", "italic", "hebrew", "gotico-antiqua", "manuscript", "rotunda", "other"]
+            "enum": [
+              "antiqua",
+              "bastarda",
+              "fraktur",
+              "textura",
+              "schwabacher",
+              "greek",
+              "italic",
+              "hebrew",
+              "gotico-antiqua",
+              "manuscript",
+              "rotunda",
+              "other"
+            ]
           },
           "default": []
         }

--- a/ocrd_froc/processor.py
+++ b/ocrd_froc/processor.py
@@ -36,7 +36,7 @@ class FROCProcessor(Processor):
     def setup(self):
 
         if 'network' not in self.parameter:
-            self.parameter['network'] = resource_filename(f'{__name__}.models', 'default.froc')
+            self.parameter['network'] = str(resource_filename(f'ocrd_froc.models', 'default.froc'))
 
         network_file = self.resolve_resource(self.parameter['network'])
         self.froc = Froc.load(network_file)

--- a/ocrd_froc/processor.py
+++ b/ocrd_froc/processor.py
@@ -20,7 +20,7 @@ from ocrd_models.ocrd_page import (
 from json import loads
 from pkg_resources import resource_string
 from ocrd_modelfactory import page_from_file
-from ocrd_froc.froc import Froc
+from .froc import Froc
 
 OCRD_TOOL = loads(resource_string(__name__, 'ocrd-tool.json'))
 
@@ -48,17 +48,15 @@ class FROCProcessor(Processor):
             textStyle = TextStyleType()
             segment.set_TextStyle(textStyle)
 
-
         method = self.parameter['method']
 
         classification_result = textStyle.get_fontFamily()
         result = {}
 
-        if classification_result == None and method != 'COCR':
+        if not classification_result and method != 'COCR':
 
             result = self.froc.classify(image)
             classification_result = ''
-
 
             font_class_priors = self.parameter['font_class_priors']
             output_font = True

--- a/ocrd_froc/processor.py
+++ b/ocrd_froc/processor.py
@@ -2,7 +2,6 @@
 Wrap FROC as an ocrd.Processor
 """
 import os
-from pkg_resources import resource_filename
 
 from ocrd import Processor
 from ocrd_utils import (
@@ -18,7 +17,7 @@ from ocrd_models.ocrd_page import (
     TextEquivType,
 )
 from json import loads
-from pkg_resources import resource_string
+from ocrd_utils import resource_filename, resource_string
 from ocrd_modelfactory import page_from_file
 from .froc import Froc
 
@@ -37,23 +36,25 @@ class FROCProcessor(Processor):
     def setup(self):
 
         if 'network' not in self.parameter:
-            self.parameter['network'] = resource_filename(__name__, 'models/default.froc')
+            self.parameter['network'] = resource_filename(f'{__name__}.models', 'default.froc')
 
         network_file = self.resolve_resource(self.parameter['network'])
         self.froc = Froc.load(network_file)
 
     def _process_segment(self, segment, image):
         textStyle = segment.get_TextStyle()
+        if textStyle and self.parameter['replace_textstyle']:
+            textStyle = None
+            segment.set_TextStyle(textStyle)
         if not textStyle:
             textStyle = TextStyleType()
             segment.set_TextStyle(textStyle)
 
-        method = self.parameter['method']
+        ocr_method = self.parameter['ocr_method']
 
-        classification_result = textStyle.get_fontFamily()
         result = {}
 
-        if not classification_result and method != 'COCR':
+        if ocr_method != 'COCR':
 
             result = self.froc.classify(image)
             classification_result = ''
@@ -94,27 +95,27 @@ class FROCProcessor(Processor):
                 textStyle.set_fontFamily(classification_result)
 
 
-        if method == 'COCR':
+        if ocr_method == 'COCR':
             fast_cocr = self.parameter['fast_cocr']
             transcription, score = self.froc.run(image,
-                                          method=method,
+                                          method=ocr_method,
                                           fast_cocr=fast_cocr)
-        elif method == 'SelOCR':
+        elif ocr_method == 'SelOCR':
             transcription, score = self.froc.run(image,
-                                          method=method,
+                                          method=ocr_method,
                                           classification_result=result)
         else:
             fast_cocr = self.parameter['fast_cocr']
             adaptive_treshold = self.parameter['adaptive_treshold']
             transcription, score = self.froc.run(image,
-                                          method=method,
+                                          method=ocr_method,
                                           classification_result=result,
                                           fast_cocr=fast_cocr,
                                           adaptive_treshold=adaptive_treshold)
         segment.set_TextEquiv([TextEquivType(Unicode=transcription, conf=score)])
 
 
-    def process(self):
+    def process(self):  # type: ignore
         """Perform font classification and text recognition (in one step) on historic documents.
 
         Open and deserialize PAGE input files and their respective images,
@@ -142,7 +143,7 @@ class FROCProcessor(Processor):
             pcgts = page_from_file(self.workspace.download_file(input_file))
             self.add_metadata(pcgts)
             page = pcgts.get_Page()
-            page_image, page_coords, image_info = self.workspace.image_from_page(
+            page_image, page_coords, _ = self.workspace.image_from_page(
                 page, page_id,
                 # prefer raw image (to meet expectation of the models, which
                 # have been trained on RGB images with both geometry and color

--- a/ocrd_froc/processor.py
+++ b/ocrd_froc/processor.py
@@ -38,7 +38,7 @@ class FROCProcessor(Processor):
 
         if 'network' not in self.parameter:
             self.parameter['network'] = resource_filename(__name__, 'models/default.froc')
-        
+
         network_file = self.resolve_resource(self.parameter['network'])
         self.froc = Froc.load(network_file)
 
@@ -46,41 +46,41 @@ class FROCProcessor(Processor):
         textStyle = segment.get_TextStyle()
         if not textStyle:
             textStyle = TextStyleType()
-            segment.set_TextStyle(textStyle) 
-        
+            segment.set_TextStyle(textStyle)
+
 
         method = self.parameter['method']
 
         classification_result = textStyle.get_fontFamily()
         result = {}
 
-        if classification_result == None and method != 'COCR' :
-            
+        if classification_result == None and method != 'COCR':
+
             result = self.froc.classify(image)
             classification_result = ''
 
-            
+
             font_class_priors = self.parameter['font_class_priors']
             output_font = True
 
-            if font_class_priors :
-                if 'other' in font_class_priors :
-                    for typegroup in self.froc.classMap.cl2id :
+            if font_class_priors:
+                if 'other' in font_class_priors:
+                    for typegroup in self.froc.classMap.cl2id:
                         result[typegroup] = 0
                     result['all'] = 1
                     output_font = False
-                else :
+                else:
                     result_sum = 0
-                    for typegroup in self.froc.classMap.cl2id :
-                        if typegroup not in font_class_priors :
+                    for typegroup in self.froc.classMap.cl2id:
+                        if typegroup not in font_class_priors:
                             result[typegroup] = 0
                         else:
                             result_sum += result[typegroup]
-                    if result_sum == 0 :
+                    if result_sum == 0:
                         result['all'] = 1
                         output_font = False
                     else:
-                        for typegroup in self.froc.classMap.cl2id :
+                        for typegroup in self.froc.classMap.cl2id:
                             result[typegroup] /= result_sum
 
             for typegroup in self.froc.classMap.cl2id:
@@ -91,27 +91,27 @@ class FROCProcessor(Processor):
                 if classification_result != '':
                     classification_result += ', '
                 classification_result += '%s:%d' % (typegroup, score)
-            
-            if output_font :
+
+            if output_font:
                 textStyle.set_fontFamily(classification_result)
-        
-        
-        if method == 'COCR' :
+
+
+        if method == 'COCR':
             fast_cocr = self.parameter['fast_cocr']
-            transcription, score = self.froc.run(image, 
-                                          method=method, 
+            transcription, score = self.froc.run(image,
+                                          method=method,
                                           fast_cocr=fast_cocr)
-        elif method == 'SelOCR' :
-            transcription, score = self.froc.run(image, 
-                                          method=method, 
+        elif method == 'SelOCR':
+            transcription, score = self.froc.run(image,
+                                          method=method,
                                           classification_result=result)
-        else :
+        else:
             fast_cocr = self.parameter['fast_cocr']
             adaptive_treshold = self.parameter['adaptive_treshold']
-            transcription, score = self.froc.run(image, 
-                                          method=method, 
-                                          classification_result=result, 
-                                          fast_cocr=fast_cocr, 
+            transcription, score = self.froc.run(image,
+                                          method=method,
+                                          classification_result=result,
+                                          fast_cocr=fast_cocr,
                                           adaptive_treshold=adaptive_treshold)
         segment.set_TextEquiv([TextEquivType(Unicode=transcription, conf=score)])
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import codecs
 import json
 
 from setuptools import setup, find_packages
 
-with codecs.open('README.md', encoding='utf-8') as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     README = f.read()
 with open('./ocrd-tool.json', 'r') as f:
     version = json.load(f)['version']

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'ocrd-froc=ocrd_froc.cli.ocrd_cli:cli',
+            'ocrd-froc-recognize=ocrd_froc.cli.ocrd_cli:cli',
         ]
     },
 )


### PR DESCRIPTION
Some basic adaptions:

- `method` -> `ocr_method`
- `ocr_method` can be `none`, which is the default, which makes Froc only do font classification
- rename `ocrd-froc` -> `ocrd-froc-recognize`
- make replacing existing textStyle an option and the default

What is still missing are the tests, I've started on them but with all the other things to do, I don't want this to stop us from releasing in ocrd_all and improving later.