### PR TITLE
Fix typos (found by `typos` and `codespell`) and improve help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Parameters:
     information. Defaults to the model bundled with ocrd_froc.
    "fast_cocr" [boolean - true]
     Whether to use optimization steps on the COCR strategy
-   "adaptive_treshold" [number - 95]
-    Treshold of certitude needed to use SelOCR when using the adaptive
+   "adaptive_threshold" [number - 95]
+    Threshold of certitude needed to use SelOCR when using the adaptive
     strategy
    "font_class_priors" [array - []]
     List of font classes which are known to be present on the data when
-    using the adaptive/SelOCR strategies. When this option is specified,
-    every font classes not included will be ignored. If 'other' is
-    included in the list, font classification will not be outputted and
-    a generic model will be used for transcriptions.
+    using the adaptive/SelOCR strategies. If this option is specified,
+    any font classes not included are ignored. If 'other' is
+    included in the list, no font classification is output and
+    a generic model is used for transcriptions.
 ```

--- a/ocrd_froc/froc.py
+++ b/ocrd_froc/froc.py
@@ -90,7 +90,7 @@ class Froc:
             Parameters
             ----------
                 output: string or file
-                    File or path to the file to which the instane has to
+                    File or path to the file to which the instance has to
                     be stored.
         """
 
@@ -108,7 +108,7 @@ class Froc:
         self.selocr.to(self.dev)
         self.cocr.to(self.dev)
 
-    def run(self, pil_image, method='adaptive', fast_cocr=True, adaptive_treshold=95, classification_result=None):
+    def run(self, pil_image, method='adaptive', fast_cocr=True, adaptive_threshold=95, classification_result=None):
 
         if method in ('SelOCR', 'adaptive') and not classification_result:
             raise ValueError(f"Froc.run(): if method is SelOCR or adaptive, classification_result is required")
@@ -120,7 +120,7 @@ class Froc:
         elif method == 'COCR':
             out = self.run_cocr(tns, fast_cocr)
         else:
-            out = self.run_adaptive(tns, classification_result, fast_cocr, adaptive_treshold)
+            out = self.run_adaptive(tns, classification_result, fast_cocr, adaptive_threshold)
 
         # constrain to image width, expand to batch format (batch size 1)
         base_width = [tns.shape[2]]
@@ -200,8 +200,8 @@ class Froc:
             return out
 
 
-    def run_adaptive(self, tns, classification_result, fast_cocr, adaptive_treshold):
-        if max(classification_result.values()) > adaptive_treshold / 100:
+    def run_adaptive(self, tns, classification_result, fast_cocr, adaptive_threshold):
+        if max(classification_result.values()) > adaptive_threshold / 100:
             return self.run_selocr(tns, classification_result)
         else:
             return self.run_cocr(tns, fast_cocr)

--- a/ocrd_froc/network.py
+++ b/ocrd_froc/network.py
@@ -242,7 +242,7 @@ class OCROnly(torch.nn.Module):
     def __init_length_map(self):
         """
         Initializes the map conversion system for convert_width(). Note
-        that it tries to cache the resuts in dat/length_map.json.
+        that it tries to cache the results in dat/length_map.json.
         """
         max_length = 2000
         try:
@@ -272,7 +272,7 @@ class OCROnly(torch.nn.Module):
         Processes an input batch.
 
         :param x: input batch
-        :return: the network's output, ready to be convered to a string
+        :return: the network's output, ready to be converted to a string
         """
         x = self.backbone(x)
         x = self.act(x)
@@ -400,7 +400,7 @@ class SelOCR(torch.nn.Module):
         single text line (because of the branching).
 
         :param x: input batch
-        :return: the network's output, ready to be convered to a string
+        :return: the network's output, ready to be converted to a string
         """
         if x.shape[0] != 1:
             raise ValueError('SelOCR cannot work on batches containing multiple inputs, sorry')
@@ -540,7 +540,7 @@ class COCR(torch.nn.Module):
         Processes an input batch
 
         :param x: input batch
-        :return: the network's output, ready to be convered to a string
+        :return: the network's output, ready to be converted to a string
         """
         scores = F.softmax(self.classifier(x), dim=2)
         res = 0
@@ -704,7 +704,7 @@ class DHCOCR(torch.nn.Module):
         Processes an input batch
 
         :param x: input batch
-        :return: the network's output, ready to be convered to a string
+        :return: the network's output, ready to be converted to a string
         """
         scores = F.softmax(self.classifier(x), dim=2)
         txt = 0

--- a/ocrd_froc/ocrd-tool.json
+++ b/ocrd_froc/ocrd-tool.json
@@ -37,14 +37,14 @@
           "type": "boolean",
           "default": true
         },
-        "adaptive_treshold": {
-          "description": "Treshold of certitude needed to use SelOCR when using the adaptive strategy",
+        "adaptive_threshold": {
+          "description": "Threshold of certitude needed to use SelOCR when using the adaptive strategy",
           "type": "number",
           "format": "integer",
           "default": 95
         },
         "font_class_priors": {
-          "description": "List of font classes which are known to be present on the data when using the adaptive/SelOCR strategies. When this option is specified, every font classes not included will be ignored. If 'other' is included in the list, font classification will not be outputted and a generic model will be used for transcriptions.",
+          "description": "List of font classes which are known to be present on the data when using the adaptive/SelOCR strategies. If this option is specified, any font classes not included are ignored. If 'other' is included in the list, no font classification is output and a generic model is used for transcriptions.",
           "type": "array",
           "items": {
             "type": "string",

--- a/ocrd_froc/processor.py
+++ b/ocrd_froc/processor.py
@@ -106,12 +106,12 @@ class FROCProcessor(Processor):
                                           classification_result=result)
         else:
             fast_cocr = self.parameter['fast_cocr']
-            adaptive_treshold = self.parameter['adaptive_treshold']
+            adaptive_threshold = self.parameter['adaptive_threshold']
             transcription, score = self.froc.run(image,
                                           method=ocr_method,
                                           classification_result=result,
                                           fast_cocr=fast_cocr,
-                                          adaptive_treshold=adaptive_treshold)
+                                          adaptive_threshold=adaptive_threshold)
         segment.set_TextEquiv([TextEquivType(Unicode=transcription, conf=score)])
 
 


### PR DESCRIPTION
Note that this also fixes the name of a parameter (`adaptive_threshold`).